### PR TITLE
Implement T1w registration to T2w for vertebral labeling

### DIFF
--- a/process_data.sh
+++ b/process_data.sh
@@ -143,14 +143,11 @@ file_t2_seg=$FILESEG
 # Flatten scan along R-L direction (to make nice figures) 
 sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
 
-# Bring vertebral level into T2 space | To remove
-#sct_register_multimodal -i label_T1w/template/PAM50_levels.nii.gz -d ${file_t2_seg}.nii.gz -o PAM50_levels2${file_t2}.nii.gz -identity 1 -x nn
-
 # Dilate segmentation to use as mask for registration
 file_t2_mask="${file_t2_seg}_dil"
 ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 35
 
-# Register T1w image to T2w FLAIR (rigid)|remove v 1??
+# Register T1w image to T2w FLAIR (rigid)
 isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
 
 # Apply transformation to T1w vertebral level
@@ -161,6 +158,7 @@ sct_qc -i ${file_t1}_reg_mask.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file
 
 # Generate QC report to assess vertebral labeling of T2w
 sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
+
 # Compute average cord CSA between C2 and C3
 sct_process_segmentation -i ${file_t2_seg}.nii.gz -vert 2:3 -vertfile PAM50_levels2${file_t2}.nii.gz -o ${PATH_RESULTS}/csa-SC_T2w.csv -append 1
 
@@ -171,7 +169,7 @@ FILES_TO_CHECK=(
   "${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
   "${SUBJECT}_T1w_RPI_r_gradcorr_seg.nii.gz" 
   "${SUBJECT}_T2w_RPI_r_gradcorr_seg.nii.gz"
-  "${SUBJECT}_T1w_RPI_r_gradcorr_seg_labeled_discs.nii.gz" # to remove, will not be there for manual seg
+  "${SUBJECT}_T1w_RPI_r_gradcorr_labels.nii.gz"
   "label_T1w/template/PAM50_levels.nii.gz"
   "PAM50_levels2${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
   

--- a/process_data.sh
+++ b/process_data.sh
@@ -143,9 +143,9 @@ file_t2_seg=$FILESEG
 # Flatten scan along R-L direction (to make nice figures) 
 sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
 
-# Dilate segmentation to use as mask for registration
+# Dilate t2 cord segmentation to use as mask for registration
 file_t2_mask="${file_t2_seg}_dil"
-ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 35
+ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 40 # test at 40
 
 # Register T1w image to T2w FLAIR (rigid)
 isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz

--- a/process_data.sh
+++ b/process_data.sh
@@ -154,7 +154,7 @@ ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 35
 isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
 
 # Apply transformation to T1w vertebral level
-isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz
+isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz -n NearestNeighbor
 
 # Generate QC report to assess T1w registration to T2w
 sct_qc -i ${file_t1}_reg_mask.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/process_data.sh
+++ b/process_data.sh
@@ -143,8 +143,18 @@ file_t2_seg=$FILESEG
 # Flatten scan along R-L direction (to make nice figures) 
 sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
 
-# Bring vertebral level into T2 space 
-sct_register_multimodal -i label_T1w/template/PAM50_levels.nii.gz -d ${file_t2_seg}.nii.gz -o PAM50_levels2${file_t2}.nii.gz -identity 1 -x nn
+# Bring vertebral level into T2 space | To remove
+#sct_register_multimodal -i label_T1w/template/PAM50_levels.nii.gz -d ${file_t2_seg}.nii.gz -o PAM50_levels2${file_t2}.nii.gz -identity 1 -x nn
+
+# Dilate segmentation to use as mask for registration
+file_t2_mask="${file_t2_seg}_dil"
+ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 25
+
+# Register T1w image to T2w FLAIR(rigid)
+isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x10x5 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
+
+# Apply transformation to T1w vertebral level | Change output name, remove v 1??
+isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels_reg_T2w.nii.gz.nii.gz
 
 # Generate QC report to assess vertebral labeling of T2w
 sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
@@ -158,7 +168,7 @@ FILES_TO_CHECK=(
   "${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
   "${SUBJECT}_T1w_RPI_r_gradcorr_seg.nii.gz" 
   "${SUBJECT}_T2w_RPI_r_gradcorr_seg.nii.gz"
-  "${SUBJECT}_T1w_RPI_r_gradcorr_seg_labeled_discs.nii.gz" # to remove, will not be ther for manual seg
+  "${SUBJECT}_T1w_RPI_r_gradcorr_seg_labeled_discs.nii.gz" # to remove, will not be there for manual seg
   "label_T1w/template/PAM50_levels.nii.gz"
   "PAM50_levels2${SUBJECT}_T2w_RPI_r_gradcorr.nii.gz"
   

--- a/process_data.sh
+++ b/process_data.sh
@@ -145,7 +145,7 @@ sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
 
 # Dilate t2 cord segmentation to use as mask for registration
 file_t2_mask="${file_t2_seg}_dil"
-ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 40 # test at 40
+ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 40
 
 # Register T1w image to T2w FLAIR (rigid)
 isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
@@ -156,7 +156,7 @@ isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}
 # Generate QC report to assess T1w registration to T2w
 sct_qc -i ${file_t1}_reg_mask.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
-# Generate QC report to assess vertebral labeling of T2w
+# Generate QC report to assess T2w vertebral labeling
 sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Compute average cord CSA between C2 and C3

--- a/process_data.sh
+++ b/process_data.sh
@@ -148,7 +148,7 @@ file_t2_mask="${file_t2_seg}_dil"
 ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 40
 
 # Register T1w image to T2w FLAIR (rigid)
-isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
+isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
 
 # Apply transformation to T1w vertebral level
 isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz -n NearestNeighbor

--- a/process_data.sh
+++ b/process_data.sh
@@ -148,13 +148,16 @@ sct_flatten_sagittal -i ${file_t2}.nii.gz -s ${file_t2_seg}.nii.gz
 
 # Dilate segmentation to use as mask for registration
 file_t2_mask="${file_t2_seg}_dil"
-ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 25
+ImageMath 3 ${file_t2_mask}.nii.gz MD ${file_t2_seg}.nii.gz 35
 
-# Register T1w image to T2w FLAIR(rigid)
-isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x10x5 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
+# Register T1w image to T2w FLAIR (rigid)|remove v 1??
+isct_antsRegistration -d 3 -m CC[ ${file_t2}.nii.gz , ${file_t1}.nii.gz , 1, 4] -t Rigid[0.5] -c 50x20x10 -f 8x4x2 -s 0x0x0 -o [_rigid, ${file_t1}_reg_mask.nii.gz] -v 1 -x ${file_t2_mask}.nii.gz
 
-# Apply transformation to T1w vertebral level | Change output name, remove v 1??
-isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels_reg_T2w.nii.gz.nii.gz
+# Apply transformation to T1w vertebral level
+isct_antsApplyTransforms -i label_T1w/template/PAM50_levels.nii.gz -r ${file_t2}.nii.gz -t _rigid0GenericAffine.mat -o PAM50_levels2${file_t2}.nii.gz
+
+# Generate QC report to assess T1w registration to T2w
+sct_qc -i ${file_t1}_reg_mask.nii.gz -s PAM50_levels2${file_t2}.nii.gz -d ${file_t2}.nii.gz -p sct_register_multimodal -qc ${PATH_QC} -qc-subject ${SUBJECT}
 
 # Generate QC report to assess vertebral labeling of T2w
 sct_qc -i ${file_t2}.nii.gz -s PAM50_levels2${file_t2}.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}


### PR DESCRIPTION
## Description
This PR adresses the problem describe in #13, when subjets moved between T1w and T2w acquisitions.
It includes:
* Instead of using `sct_register_multimodal` to get T2w vertebral levels, as described in #20, T1w image is registered to T2w image with mask (dilation of T2w cord segmentation) and the transformation is applied on T1w vertebral levels. Dilation of 40 was chosen and tested, presents better results with a dilation of 35, I wouln't go higher in case it exceeds boundaries of the head in the image.
* Files in `FILES_TO_CHECK` list were modified accordingly and to resovle issue #23 so subjects using manual labeling don't present an error of a missing file.
## Linked issues
Fixes #20 , fixes #23 and  closes #13